### PR TITLE
Do not append model parameters to the redirect urls

### DIFF
--- a/src/main/java/uk/co/squadlist/web/controllers/AdminController.java
+++ b/src/main/java/uk/co/squadlist/web/controllers/AdminController.java
@@ -202,7 +202,7 @@ public class AdminController {
     }
 
     private ModelAndView redirectToAdminScreen() {
-        return new ModelAndView(new RedirectView(urlBuilder.adminUrl()));
+        return redirectionTo(urlBuilder.adminUrl());
     }
 
     private ModelAndView renderEditInstanceDetailsForm(final InstanceDetails instanceDetails) throws SignedInMemberRequiredException, UnknownInstanceException {
@@ -210,6 +210,12 @@ public class AdminController {
                 addObject("instanceDetails", instanceDetails).
                 addObject("memberOrderings", MEMBER_ORDERINGS).
                 addObject("governingBodies", GOVERNING_BODIES);
+    }
+
+    private ModelAndView redirectionTo(String url) {
+        RedirectView redirectView = new RedirectView(url);
+        redirectView.setExposeModelAttributes(false);
+        return new ModelAndView(redirectView);
     }
 
 }

--- a/src/main/java/uk/co/squadlist/web/controllers/AvailabilityOptionsController.java
+++ b/src/main/java/uk/co/squadlist/web/controllers/AvailabilityOptionsController.java
@@ -147,7 +147,7 @@ public class AvailabilityOptionsController {
     }
 
     private ModelAndView redirectToAdmin() {
-        return new ModelAndView(new RedirectView(urlBuilder.adminUrl()));
+        return redirectionTo(urlBuilder.adminUrl());
     }
 
     private ModelAndView renderDeleteForm(final AvailabilityOption a, InstanceSpecificApiClient api) throws HttpFetchException, IOException, SignedInMemberRequiredException, UnknownInstanceException {
@@ -157,6 +157,12 @@ public class AvailabilityOptionsController {
         return viewFactory.getViewForLoggedInUser("deleteAvailabilityOption").
                 addObject("availabilityOption", a).
                 addObject("alternatives", alternatives);
+    }
+
+    private ModelAndView redirectionTo(String url) {
+        RedirectView redirectView = new RedirectView(url);
+        redirectView.setExposeModelAttributes(false);
+        return new ModelAndView(redirectView);
     }
 
 }

--- a/src/main/java/uk/co/squadlist/web/controllers/ExceptionHandler.java
+++ b/src/main/java/uk/co/squadlist/web/controllers/ExceptionHandler.java
@@ -89,7 +89,7 @@ public class ExceptionHandler implements HandlerExceptionResolver, Ordered {
         }
 
         if (e instanceof SignedInMemberRequiredException) {
-            return new ModelAndView(new RedirectView(urlBuilder.loginUrl()));
+            return redirectionTo(urlBuilder.loginUrl());
         }
 
         String path = (String) request.getAttribute(RequestDispatcher.ERROR_REQUEST_URI);
@@ -106,6 +106,12 @@ public class ExceptionHandler implements HandlerExceptionResolver, Ordered {
     @Override
     public int getOrder() {
         return Integer.MIN_VALUE;
+    }
+
+    private ModelAndView redirectionTo(String url) {
+        RedirectView redirectView = new RedirectView(url);
+        redirectView.setExposeModelAttributes(false);
+        return new ModelAndView(redirectView);
     }
 
 }

--- a/src/main/java/uk/co/squadlist/web/controllers/LoginController.java
+++ b/src/main/java/uk/co/squadlist/web/controllers/LoginController.java
@@ -68,7 +68,7 @@ public class LoginController {
             if (authenticatedMember != null) {
                 log.info("Auth successful for user: " + username);
                 loggedInUserService.setSignedIn(authenticatedUsersAccessToken);
-                return new ModelAndView(new RedirectView(urlBuilder.getBaseUrl()));
+                return redirectionTo(urlBuilder.getBaseUrl());
             }
         }
 
@@ -78,7 +78,7 @@ public class LoginController {
     @RequestMapping(value = "/logout", method = {RequestMethod.GET})
     public ModelAndView logout() {
         loggedInUserService.cleanSignedIn();
-        return new ModelAndView(new RedirectView(urlBuilder.loginUrl()));
+        return redirectionTo(urlBuilder.loginUrl());
     }
 
     private ModelAndView renderLoginScreen(boolean errors, String username) throws UnknownInstanceException {
@@ -97,6 +97,12 @@ public class LoginController {
             log.error("Uncaught error", e);    // TODO
             return null;
         }
+    }
+
+    private ModelAndView redirectionTo(String url) {
+        RedirectView redirectView = new RedirectView(url);
+        redirectView.setExposeModelAttributes(false);
+        return new ModelAndView(redirectView);
     }
 
 }

--- a/src/main/java/uk/co/squadlist/web/controllers/OutingsController.java
+++ b/src/main/java/uk/co/squadlist/web/controllers/OutingsController.java
@@ -178,7 +178,7 @@ public class OutingsController {
             }
 
             final String outingsViewForNewOutingsSquadAndMonth = urlBuilder.outings(newOuting.getSquad(), new DateTime(newOuting.getDate()).toString("yyyy-MM"));
-            return new ModelAndView(new RedirectView(outingsViewForNewOutingsSquadAndMonth));
+            return redirectionTo(outingsViewForNewOutingsSquadAndMonth);
 
         } catch (InvalidOutingException e) {
             result.addError(new ObjectError("outing", e.getMessage()));
@@ -221,7 +221,7 @@ public class OutingsController {
         loggedInUserApi.deleteOuting(outing.getId());
 
         final String exitUrl = outing.getSquad() == null ? urlBuilder.outings(outing.getSquad()) : urlBuilder.outingsUrl();
-        return new ModelAndView(new RedirectView(exitUrl));
+        return redirectionTo(exitUrl);
     }
 
     @RequiresOutingPermission(permission = Permission.EDIT_OUTING)
@@ -300,7 +300,7 @@ public class OutingsController {
     }
 
     private ModelAndView redirectToOuting(final Outing updatedOuting) {
-        return new ModelAndView(new RedirectView(urlBuilder.outingUrl(updatedOuting)));
+        return redirectionTo(urlBuilder.outingUrl(updatedOuting));
     }
 
     private ModelAndView renderNewOutingForm(OutingDetails outingDetails, InstanceSpecificApiClient api) throws UnknownSquadException, SignedInMemberRequiredException, UnknownInstanceException {
@@ -339,5 +339,12 @@ public class OutingsController {
         String notes = outingDetails.getNotes();
         return new Outing(squad, date, notes);
     }
+
+    private ModelAndView redirectionTo(String url) {
+        RedirectView redirectView = new RedirectView(url);
+        redirectView.setExposeModelAttributes(false);
+        return new ModelAndView(redirectView);
+    }
+
 
 }

--- a/src/main/java/uk/co/squadlist/web/controllers/SquadsController.java
+++ b/src/main/java/uk/co/squadlist/web/controllers/SquadsController.java
@@ -66,7 +66,7 @@ public class SquadsController {
 
         try {
             loggedInUserApi.createSquad(squadDetails.getName());
-            return new ModelAndView(new RedirectView(urlBuilder.adminUrl()));
+            return redirectionTo(urlBuilder.adminUrl());
 
         } catch (InvalidSquadException e) {
             log.info("Invalid squad");
@@ -91,7 +91,7 @@ public class SquadsController {
 
         final Squad squad = loggedInUserApi.getSquad(id);
         loggedInUserApi.deleteSquad(squad);
-        return new ModelAndView(new RedirectView(urlBuilder.adminUrl()));
+        return redirectionTo(urlBuilder.adminUrl());
     }
 
     @RequestMapping(value = "/squad/{id}/edit", method = RequestMethod.GET)
@@ -129,7 +129,7 @@ public class SquadsController {
         log.info("Setting squad members to " + updatedSquadMembers.size() + " members: " + updatedSquadMembers);
         loggedInUserApi.setSquadMembers(squad.getId(), updatedSquadMembers);
 
-        return new ModelAndView(new RedirectView(urlBuilder.adminUrl()));
+        return redirectionTo(urlBuilder.adminUrl());
     }
 
     private ModelAndView renderNewSquadForm(SquadDetails squadDetails) throws SignedInMemberRequiredException, UnknownInstanceException {
@@ -146,6 +146,12 @@ public class SquadsController {
                 addObject("squadDetails", squadDetails).
                 addObject("squadMembers", squadMembers).
                 addObject("availableMembers", availableMembers);
+    }
+
+    private ModelAndView redirectionTo(String url) {
+        RedirectView redirectView = new RedirectView(url);
+        redirectView.setExposeModelAttributes(false);
+        return new ModelAndView(redirectView);
     }
 
 }


### PR DESCRIPTION
Round up all usages of RedirectVIew and explicitly set them to not append model parameters to the url.

For example, when logging out the Google Analytics global variable should not appear on the login screens url.

There is probably Spring config todo this globally but tbh it's probably easier to just do this rather than try to find the source of the magic.