### PR TITLE
Install Honeycomb observability wrapper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
-FROM openjdk:11-jre
+FROM eclipse-temurin:17-alpine
 COPY target/squadlist-0.0.1-SNAPSHOT.jar /opt/squadlist/squadlist-0.0.1-SNAPSHOT.jar
-CMD ["java","-jar","/opt/squadlist/squadlist-0.0.1-SNAPSHOT.jar", "--spring.config.location=/opt/squadlist/conf/squadlist.properties"]
+
+COPY honeycomb/honeycomb-opentelemetry-javaagent-1.3.0.jar /opt/honeycomb-opentelemetry-javaagent-1.3.0.jar
+
+CMD ["java", "-XshowSettings:vm", "-XX:+PrintCommandLineFlags", "-XX:MaxRAMPercentage=75", "-javaagent:/opt/honeycomb-opentelemetry-javaagent-1.3.0.jar", "-jar", "/opt/squadlist/squadlist-0.0.1-SNAPSHOT.jar", "--spring.config.location=/opt/squadlist/conf/squadlist.properties"]
+
+


### PR DESCRIPTION
Enables the honeycomb.io telemetry wrapper.
No PIP is captured in these events.