### PR TITLE
Reduce outing inline verify calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ mvn spring-boot:run
 ## Building the Squadlist API Swagger client
 
 This UI app talks to the Squadlist API (which is currently private and not yet publicly documented) using a client jar generated from the API's OpenAPI definition.
-When a new end point is added to the API, we need to regenerate the client jar before we can call the new end point.a
+When a new end point is added to the API, we need to regenerate the client jar before we can call the new end point.
 
 
 ## Building container images

--- a/src/main/java/uk/co/squadlist/web/controllers/OutingsController.java
+++ b/src/main/java/uk/co/squadlist/web/controllers/OutingsController.java
@@ -115,17 +115,21 @@ public class OutingsController {
         InstanceSpecificApiClient loggedInUserApi = loggedInUserService.getApiClientForLoggedInUser();
 
         final Outing outing = loggedInUserApi.getOuting(id);
+        final Map<String, AvailabilityOption> outingAvailability = loggedInUserApi.getOutingAvailability(outing.getId());
+        final List<Squad> squads = loggedInUserApi.getSquads();
 
-        final ModelAndView mv = viewFactory.getViewForLoggedInUser("outing").
+        final List<Member> squadMembers = loggedInUserApi.getSquadMembers(outing.getSquad().getId());
+        final List<Member> activeMembers = activeMemberFilter.extractActive(squadMembers);
+
+        return viewFactory.getViewForLoggedInUser("outing").
                 addObject("title", outing.getSquad().getName() + " - " + dateFormatter.dayMonthYearTime(outing.getDate())).
                 addObject("outing", outing).
                 addObject("outingMonths", getOutingMonthsFor(outing.getSquad(), loggedInUserApi)).
                 addObject("squad", outing.getSquad()).
-                addObject("squadAvailability", loggedInUserApi.getOutingAvailability(outing.getId())).
-                addObject("squads", loggedInUserApi.getSquads()).
-                addObject("members", activeMemberFilter.extractActive(loggedInUserApi.getSquadMembers(outing.getSquad().getId()))).
-                addObject("month", ISODateTimeFormat.yearMonth().print(outing.getDate().getTime()));  // TODO push to date parser - local time
-        return mv;
+                addObject("squadAvailability", outingAvailability).
+                addObject("squads", squads).
+                addObject("members", activeMembers).
+                addObject("month", ISODateTimeFormat.yearMonth().print(outing.getDate().getTime()));    // TODO push to date parser - local time
     }
 
     @RequestMapping("/outings/{id}.csv")

--- a/src/main/java/uk/co/squadlist/web/controllers/OutingsController.java
+++ b/src/main/java/uk/co/squadlist/web/controllers/OutingsController.java
@@ -116,15 +116,15 @@ public class OutingsController {
 
         final Outing outing = loggedInUserApi.getOuting(id);
 
-        final ModelAndView mv = viewFactory.getViewForLoggedInUser("outing");
-        mv.addObject("title", outing.getSquad().getName() + " - " + dateFormatter.dayMonthYearTime(outing.getDate()));
-        mv.addObject("outing", outing);
-        mv.addObject("outingMonths", getOutingMonthsFor(outing.getSquad(), loggedInUserApi));
-        mv.addObject("squad", outing.getSquad());
-        mv.addObject("squadAvailability", loggedInUserApi.getOutingAvailability(outing.getId()));
-        mv.addObject("squads", loggedInUserApi.getSquads());
-        mv.addObject("members", activeMemberFilter.extractActive(loggedInUserApi.getSquadMembers(outing.getSquad().getId())));
-        mv.addObject("month", ISODateTimeFormat.yearMonth().print(outing.getDate().getTime()));  // TODO push to date parser - local time
+        final ModelAndView mv = viewFactory.getViewForLoggedInUser("outing").
+                addObject("title", outing.getSquad().getName() + " - " + dateFormatter.dayMonthYearTime(outing.getDate())).
+                addObject("outing", outing).
+                addObject("outingMonths", getOutingMonthsFor(outing.getSquad(), loggedInUserApi)).
+                addObject("squad", outing.getSquad()).
+                addObject("squadAvailability", loggedInUserApi.getOutingAvailability(outing.getId())).
+                addObject("squads", loggedInUserApi.getSquads()).
+                addObject("members", activeMemberFilter.extractActive(loggedInUserApi.getSquadMembers(outing.getSquad().getId()))).
+                addObject("month", ISODateTimeFormat.yearMonth().print(outing.getDate().getTime()));  // TODO push to date parser - local time
         return mv;
     }
 

--- a/src/main/java/uk/co/squadlist/web/views/model/DisplayMember.java
+++ b/src/main/java/uk/co/squadlist/web/views/model/DisplayMember.java
@@ -1,0 +1,23 @@
+package uk.co.squadlist.web.views.model;
+
+import uk.co.squadlist.web.model.Member;
+
+public class DisplayMember {
+
+    private final Member member;
+    private final boolean editable;
+
+    public DisplayMember(Member member, boolean editable) {
+        this.member = member;
+        this.editable = editable;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public boolean isEditable() {
+        return editable;
+    }
+
+}

--- a/src/main/resources/includes/displayMember.vm
+++ b/src/main/resources/includes/displayMember.vm
@@ -1,0 +1,8 @@
+#if($displayMember.editable)
+    <a href="$urlBuilder.applicationUrl("/member/$displayMember.member.id")"
+        #if ($displayMember.member.availabilityLastUpdated) title="Availability last updated $dateFormatter.timeSince($!$displayMember.member.availabilityLastUpdated)" #end >
+        $displayMember.member.displayName
+    </a>
+#else
+    $displayMember.member.displayName
+#end

--- a/src/main/resources/outing.vm
+++ b/src/main/resources/outing.vm
@@ -42,17 +42,17 @@
 			#end
 									
 			<table style="font-size: 14px;" class="table table-striped">				
-				#foreach($member in $members )					
+				#foreach($displayMember in $members)
 					<tr>
 				    	<td>
-				   			#parse('includes/member.vm')
+				   			#parse('includes/displayMember.vm')
 				   		</td>				   		
 				   		<td>
-				   			$!member.sweepOarSide
+				   			$!displayMember.member.sweepOarSide
 				   		</td>
 				   		<td>
 				   			#set($availability = '')
-							#set($availability = $squadAvailability.get(${member.id}))
+							#set($availability = $squadAvailability.get(${displayMember.member.id}))
 							#parse('includes/availability.vm')							
 						</td>
 					</tr>


### PR DESCRIPTION
The permissions helper creates many repeated calls to verify the logged in user while iterating through the list of members for a single outing.

We have optimise this by introducing  a display object and pushing the decision making (can the logged in user edit this member) up to the controller.

<img width="928" alt="Screenshot 2022-07-20 at 16 28 25" src="https://user-images.githubusercontent.com/150238/180027767-5ac3fc97-7f34-4cdf-90c1-415bead34c95.png">
