### PR TITLE
My outings notification badge only looks 1 month ahead

### DIFF
--- a/src/main/java/uk/co/squadlist/web/services/OutingAvailabilityCountsService.java
+++ b/src/main/java/uk/co/squadlist/web/services/OutingAvailabilityCountsService.java
@@ -39,7 +39,7 @@ public class OutingAvailabilityCountsService {
 	public int getPendingOutingsCountFor(String memberId, InstanceSpecificApiClient api) {
 		int pendingCount = 0;
 		for (OutingAvailability outingAvailability : api.getAvailabilityFor(memberId, 
-				DateHelper.startOfCurrentOutingPeriod().toDate(), DateHelper.oneYearFromNow().toDate())) {
+				DateHelper.startOfCurrentOutingPeriod().toDate(), DateHelper.oneMonthFromNow().toDate())) {
 			if (outingAvailability.getAvailabilityOption() == null) {
 				pendingCount++;
 			}

--- a/src/main/java/uk/co/squadlist/web/views/DateHelper.java
+++ b/src/main/java/uk/co/squadlist/web/views/DateHelper.java
@@ -59,11 +59,15 @@ public class DateHelper {
 	public static DateTime startOfCurrentOutingPeriod() {
 		return midnightYesterday().toDateTime();
 	}
+
+	public static DateTime oneMonthFromNow() {
+		return DateTime.now().plusMonths(1);
+	}
 	
 	public static DateTime oneYearFromNow() {
 		return DateTime.now().plusYears(1);
 	}
-	
+
 	public static DateTime endOfCurrentOutingPeriod() {
 		return startOfCurrentOutingPeriod().plusWeeks(2);
 	}


### PR DESCRIPTION
My outings notification badge in the nav bar is a count of upcoming outings which the member has not provided their availability for.

This is intended as a reminder to the user that that haven't provided availability for upcoming outings.

It should not look so far ahead as it currently does.
Rather than a the current 1 year the notification will only consider outings within the next month.

Reminding about availability decisions too far out is not helpful.