### PR TITLE
Availiability CSV export

### DIFF
--- a/src/main/java/uk/co/squadlist/web/controllers/AvailabilityController.java
+++ b/src/main/java/uk/co/squadlist/web/controllers/AvailabilityController.java
@@ -1,7 +1,9 @@
 package uk.co.squadlist.web.controllers;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.format.ISODateTimeFormat;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -14,15 +16,16 @@ import uk.co.squadlist.client.swagger.api.DefaultApi;
 import uk.co.squadlist.model.swagger.*;
 import uk.co.squadlist.web.auth.LoggedInUserService;
 import uk.co.squadlist.web.context.InstanceConfig;
+import uk.co.squadlist.web.exceptions.SignedInMemberRequiredException;
 import uk.co.squadlist.web.services.PreferredSquadService;
 import uk.co.squadlist.web.services.filters.ActiveMemberFilter;
-import uk.co.squadlist.web.views.DateHelper;
-import uk.co.squadlist.web.views.NavItemsBuilder;
-import uk.co.squadlist.web.views.ViewFactory;
+import uk.co.squadlist.web.views.*;
+import uk.co.squadlist.web.views.model.DisplayMember;
 import uk.co.squadlist.web.views.model.NavItem;
 
+import javax.servlet.http.HttpServletResponse;
 import java.math.BigDecimal;
-import java.util.Date;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +40,7 @@ public class AvailabilityController {
     private final NavItemsBuilder navItemsBuilder;
     private final InstanceConfig instanceConfig;
     private final DisplayMemberFactory displayMemberFactory;
+    private CsvOutputRenderer csvOutputRenderer;
 
     @Autowired
     public AvailabilityController(PreferredSquadService preferredSquadService, ViewFactory viewFactory,
@@ -44,7 +48,8 @@ public class AvailabilityController {
                                   LoggedInUserService loggedInUserService,
                                   NavItemsBuilder navItemsBuilder,
                                   InstanceConfig instanceConfig,
-                                  DisplayMemberFactory displayMemberFactory) {
+                                  DisplayMemberFactory displayMemberFactory,
+                                  CsvOutputRenderer csvOutputRenderer) {
         this.preferredSquadService = preferredSquadService;
         this.viewFactory = viewFactory;
         this.activeMemberFilter = activeMemberFilter;
@@ -52,6 +57,7 @@ public class AvailabilityController {
         this.navItemsBuilder = navItemsBuilder;
         this.instanceConfig = instanceConfig;
         this.displayMemberFactory = displayMemberFactory;
+        this.csvOutputRenderer = csvOutputRenderer;
     }
 
     @RequestMapping("/availability")
@@ -85,20 +91,18 @@ public class AvailabilityController {
             List<Member> activeSquadMembers = activeMemberFilter.extractActive(squadMembers);
 
             boolean current = false;
-            Date startDate = DateHelper.startOfCurrentOutingPeriod().toDate();
-            Date endDate = DateHelper.endOfCurrentOutingPeriod().toDate();
+            DateTime startDate = DateHelper.startOfCurrentOutingPeriod();
+            DateTime endDate = DateHelper.endOfCurrentOutingPeriod();
             if (month != null) {
                 final DateTime monthDateTime = ISODateTimeFormat.yearMonth().parseDateTime(month);    // TODO Can be moved to spring?
-                startDate = monthDateTime.toDate();
-                endDate = monthDateTime.plusMonths(1).toDate();
+                startDate = monthDateTime;
+                endDate = monthDateTime.plusMonths(1);
             } else {
                 current = true;
             }
 
-            final List<OutingWithSquadAvailability> squadAvailability = swaggerApiClientForLoggedInUser.getSquadAvailability(squad.getId(), new DateTime(startDate), new DateTime(endDate));
-            Map<String, AvailabilityOption> memberOutingAvailabilityMap = decorateOutingsWithMembersAvailability(squadAvailability);
-
-            final List<Outing> outings = swaggerApiClientForLoggedInUser.outingsGet(instance.getId(), squad.getId(), new DateTime(startDate), new DateTime(endDate));
+            final List<Outing> outings = swaggerApiClientForLoggedInUser.outingsGet(instance.getId(), squad.getId(), startDate, endDate);
+            Map<String, AvailabilityOption> memberOutingAvailabilityMap = decorateOutingsWithMembersAvailability(squad, startDate, endDate);
 
             return viewFactory.getViewFor("availability", instance).
                     addObject("squads", squads).
@@ -112,21 +116,76 @@ public class AvailabilityController {
                     addObject("month", month);
 
         } else {
-            return viewFactory.getViewFor("availability", instance).
-                    addObject("squads", squads).
-                    addObject("title", squad.getName() + " availability").
-                    addObject("navItems", navItems);
-
+            return null;    // TODO this should 404
         }
     }
 
-    private Map<String, AvailabilityOption> decorateOutingsWithMembersAvailability(final List<uk.co.squadlist.model.swagger.OutingWithSquadAvailability> squadAvailability) {
+    @RequestMapping("/availability/{squadId}.csv")
+    public void squadAvailabilityCsv(@PathVariable String squadId, @RequestParam(value = "month", required = false) String month, HttpServletResponse response) throws Exception {
+        DefaultApi swaggerApiClientForLoggedInUser = loggedInUserService.getSwaggerApiClientForLoggedInUser();
+        Instance instance = swaggerApiClientForLoggedInUser.getInstance(instanceConfig.getInstance());
+
+        final Squad squad = preferredSquadService.resolveSquad(squadId, swaggerApiClientForLoggedInUser, instance);
+
+        if (squad != null) {
+            List<Member> squadMembers = swaggerApiClientForLoggedInUser.getSquadMembers(squad.getId());
+            List<Member> activeSquadMembers = activeMemberFilter.extractActive(squadMembers);
+
+            DateTime startDate = DateHelper.startOfCurrentOutingPeriod();
+            DateTime endDate = DateHelper.endOfCurrentOutingPeriod();
+            if (month != null) {
+                final DateTime monthDateTime = ISODateTimeFormat.yearMonth().parseDateTime(month);    // TODO Can be moved to spring?
+                startDate = monthDateTime;
+                endDate = monthDateTime.plusMonths(1);
+            }
+
+            final List<Outing> outings = swaggerApiClientForLoggedInUser.outingsGet(instance.getId(), squad.getId(), startDate, endDate);
+            Map<String, AvailabilityOption> memberOutingAvailabilityMap = decorateOutingsWithMembersAvailability(squad, startDate, endDate);
+
+            DateFormatter dateFormatter = new DateFormatter(DateTimeZone.forID(instance.getTimeZone()));
+
+            // Headings are Name the the outing dates
+            // Second row is the outing notes
+            ArrayList<String> headings = Lists.newArrayList("Name");
+            List<String> notes = Lists.newArrayList();
+            notes.add(null);
+
+            for(Outing outing: outings) {
+                headings.add(dateFormatter.dayMonthYearTime(outing.getDate()));
+                notes.add(outing.getNotes());
+            }
+
+            // Iterate through the rows of squad members, outputting rows of outing availability
+            final List<List<String>> rows = Lists.newArrayList();
+            rows.add(notes);
+
+            for (Member member : activeSquadMembers) {
+                DisplayMember displayMember = new DisplayMember(member, false);
+                List<String> cells = Lists.newArrayList();
+                cells.add(displayMember.getDisplayName());
+
+                for(Outing outing: outings) {
+                    AvailabilityOption availabilityOption = memberOutingAvailabilityMap.get(outing.getId() + "-" + member.getId());
+                    cells.add(availabilityOption != null ? availabilityOption.getLabel() : "");
+                }
+                rows.add(cells);
+            }
+
+            csvOutputRenderer.renderCsvResponse(response, headings, rows);
+        }
+    }
+
+    private Map<String, AvailabilityOption> decorateOutingsWithMembersAvailability(Squad squad, DateTime startDate, DateTime endDate) throws SignedInMemberRequiredException, ApiException {
+        DefaultApi swaggerApiClientForLoggedInUser = loggedInUserService.getSwaggerApiClientForLoggedInUser();
+        final List<OutingWithSquadAvailability> squadAvailability = swaggerApiClientForLoggedInUser.getSquadAvailability(squad.getId(), new DateTime(startDate), new DateTime(endDate));
+
         final Map<String, AvailabilityOption> allAvailability = Maps.newHashMap();
 
         for (OutingWithSquadAvailability outingWithSquadAvailability : squadAvailability) {
             final Map<String, AvailabilityOption> outingAvailability = outingWithSquadAvailability.getAvailability();
-            for (String member : outingAvailability.keySet()) {
-                allAvailability.put(outingWithSquadAvailability.getOuting().getId() + "-" + member, outingAvailability.get(member));
+            for (String memberId : outingAvailability.keySet()) {
+                String key = outingWithSquadAvailability.getOuting().getId() + "-" + memberId;    // TODO this magic format is very questionable
+                allAvailability.put(key, outingAvailability.get(memberId));
             }
         }
         return allAvailability;

--- a/src/main/java/uk/co/squadlist/web/controllers/AvailabilityController.java
+++ b/src/main/java/uk/co/squadlist/web/controllers/AvailabilityController.java
@@ -81,13 +81,10 @@ public class AvailabilityController {
         final Squad squad = preferredSquadService.resolveSquad(squadId, swaggerApiClientForLoggedInUser, instance);
 
         if (squad != null) {
-            ModelAndView mv = viewFactory.getViewFor("availability", instance).
-                    addObject("squads", squads).
-                    addObject("navItems", navItems);
-
             List<Member> squadMembers = swaggerApiClientForLoggedInUser.getSquadMembers(squad.getId());
             List<Member> activeSquadMembers = activeMemberFilter.extractActive(squadMembers);
 
+            boolean current = false;
             Date startDate = DateHelper.startOfCurrentOutingPeriod().toDate();
             Date endDate = DateHelper.endOfCurrentOutingPeriod().toDate();
             if (month != null) {
@@ -95,7 +92,7 @@ public class AvailabilityController {
                 startDate = monthDateTime.toDate();
                 endDate = monthDateTime.plusMonths(1).toDate();
             } else {
-                mv.addObject("current", true);
+                current = true;
             }
 
             final List<OutingWithSquadAvailability> squadAvailability = swaggerApiClientForLoggedInUser.getSquadAvailability(squad.getId(), new DateTime(startDate), new DateTime(endDate));
@@ -103,19 +100,21 @@ public class AvailabilityController {
 
             final List<Outing> outings = swaggerApiClientForLoggedInUser.outingsGet(instance.getId(), squad.getId(), new DateTime(startDate), new DateTime(endDate));
 
-            mv.addObject("squad", squad).
+            return viewFactory.getViewFor("availability", instance).
+                    addObject("squads", squads).
                     addObject("title", squad.getName() + " availability").
+                    addObject("navItems", navItems).addObject("squad", squad).
                     addObject("members", displayMemberFactory.toDisplayMembers(activeSquadMembers, loggedInMember)).
                     addObject("outings", outings).
                     addObject("squadAvailability", memberOutingAvailabilityMap).
                     addObject("outingMonths", getOutingMonthsFor(instance, squad, swaggerApiClientForLoggedInUser)).
+                    addObject("current", current).
                     addObject("month", month);
-
-            return mv;
 
         } else {
             return viewFactory.getViewFor("availability", instance).
                     addObject("squads", squads).
+                    addObject("title", squad.getName() + " availability").
                     addObject("navItems", navItems);
 
         }

--- a/src/main/java/uk/co/squadlist/web/urls/UrlBuilder.java
+++ b/src/main/java/uk/co/squadlist/web/urls/UrlBuilder.java
@@ -133,9 +133,15 @@ public class UrlBuilder {
 	public String availability(Squad squad) {
 		return applicationUrl("/availability/" + squad.getId());
 	}
+	public String availabilityCsv(Squad squad) {
+		return availability(squad) + ".csv";
+	}
 
 	public String availability(Squad squad, String month) {
 		return availability(squad) + "?month=" + month;
+	}
+	public String availabilityCsv(Squad squad, String month) {
+		return availabilityCsv(squad) + (month != null ? "?month=" + month : "");
 	}
 
 	public String editInstanceSettings() {

--- a/src/main/resources/availability.vm
+++ b/src/main/resources/availability.vm
@@ -98,6 +98,14 @@
 				#end
 			</div>
 		</div>
+
+        #if($showExport)
+            <div class="row">
+                <div class="col-xs-12">
+                    <p align="right"><a href="$urlBuilder.availabilityCsv($squad, $month)">Export as CSV</a><p/>
+                </div>
+            </div>
+        #end
 		
 	#else				
 		<div class="row">


### PR DESCRIPTION
The Availability grid can be exported as a CSV file to assist clubs who are transcribing this information into other systems.

<img width="876" alt="Screenshot 2022-08-04 at 20 55 04" src="https://user-images.githubusercontent.com/150238/182941207-1d57ee19-7145-41ce-885d-4575e0af8b9b.png">

ie.
```
Name,3 Aug 2022 08:00,3 Aug 2022 11:30,3 Aug 2022 13:45,4 Aug 2022 08:00,5 Aug 2022 08:00,7 Aug 2022 13:15,9 Aug 2022 19:30,11 Aug 2022 08:00,16 Aug 2022 19:45
,,,Testing updates,,,sdsdsd,,,Moved; does it change in iCal?
No Role,,,,,,,,,
Test2,,,Not available,Available,Available,Available,Available,,Available
Test Test3,,,,,,,,,
Test6,,,,,,,,,
```